### PR TITLE
Fix assert on buffer length in write_cmd_args

### DIFF
--- a/src/sgp41.rs
+++ b/src/sgp41.rs
@@ -138,7 +138,7 @@ where
         let (command, delay) = cmd.as_tuple();
 
         let mut buf = [0; 8];
-        assert!(command.to_ne_bytes().len() + args.len() * 3 < buf.len());
+        assert!(command.to_ne_bytes().len() + args.len() * 3 <= buf.len());
 
         buf[0..2].copy_from_slice(&command.to_be_bytes());
 


### PR DESCRIPTION
Encountered a problematic bounds check in write_cmd_args while testing out this crate.